### PR TITLE
Add a command to generate UUID V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,55 @@
 Discover the future value of the key field of a Meilisearch API key before its generation to automatize deployments from the ground-up.
 
+## Overview
+
 ```bash
-blitz generate master_key d7d30ffe-ec60-484f-84f8-1c8b7d0ac352 c5a18797-621c-42b5-81bd-23fbf0202364
+SUBCOMMANDS:
+    generate-keys     Generate keys field value for a list of UIDs and a master key
+    generate-uuids    Generate uuid(s) V4
+    help              Print this message or the help of the given subcommand(s)
+```
+
+## generate-keys
+
+```bash
+blitz generate-keys master_key d7d30ffe-ec60-484f-84f8-1c8b7d0ac352 c5a18797-621c-42b5-81bd-23fbf0202364
 ```
 
 ```bash
  uid                                  | 🔑 key
  d7d30ffe-ec60-484f-84f8-1c8b7d0ac352 | h2mHLjq0eu9N6xO4padE3ZRbToQgi1X7IPb7ePQdvHY
  c5a18797-621c-42b5-81bd-23fbf0202364 | MeU0XSwYywmYnMNUJpg5Degyqk_QqKIWQcyIDf4Z-YM
+ ```
+
+```bash
+Generate keys field value for a list of UIDs and a master key
+
+USAGE:
+    blitz generate-keys <MASTER_KEY> [UIDS]...
+
+ARGS:
+    <MASTER_KEY>    Meilisearch master key
+    <UIDS>...       API key uids
+```
+
+## generate-uuids
+
+```bash
+blitz generate-uuids 3
 ```
 
 ```bash
-USAGE:
-    blitz generate <master-key> [uids]...
+8b566165-1cb5-4b8d-890a-23e0c9d670b6
+cc339590-86cd-4f42-b06e-faee781cff05
+b94505dd-2ed0-4c6c-a079-088e93bceb26
+```
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+```bash
+Generate uuid(s) V4
+
+USAGE:
+    blitz generate-uuids [COUNT]
 
 ARGS:
-    <master-key>    Meilisearch master key
-    <uids>...       API key uids
+    <COUNT>    Number of uuids V4 to generate [default: 1]
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,12 @@ use prettytable::{format, Cell, Row, Table};
 fn main() {
     let opt = Options::from_args();
     match opt.command {
-        Command::Generate { master_key, uids } => {
+        Command::GenerateKeys { master_key, uids } => {
             generate_keys(master_key, uids);
-        }
+        },
+        Command::GenerateUuids { count } => {
+            generate_uuids(count);
+        },
     }
 }
 
@@ -62,4 +65,13 @@ fn print_keys(keys: &Vec<APIKey>) -> () {
     }
 
     table.printstd();
+}
+
+/// Generate UUIDv4s
+fn generate_uuids(mut count: usize) -> () {
+    while count > 0 {
+        let uuid = Uuid::new_v4();
+        println!("{}", uuid.to_string());
+        count -= 1;
+    }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -9,11 +9,17 @@ pub struct Options {
 
 #[derive(Debug, Parser)]
 pub enum Command {
-    /// Generate key field value
-    Generate {
+    /// Generate keys field value for a list of UIDs and a master key.
+    GenerateKeys {
         /// Meilisearch master key
         master_key: String,
         /// API key uids
         uids: Vec<String>,
     },
+    /// Generate uuid(s) V4
+    GenerateUuids {
+        /// Number of uuids V4 to generate
+        #[clap(default_value = "1")]
+        count: usize,
+    }
 }


### PR DESCRIPTION
```bash
blitz generate-uuids 3
```

```bash
8b566165-1cb5-4b8d-890a-23e0c9d670b6
cc339590-86cd-4f42-b06e-faee781cff05
b94505dd-2ed0-4c6c-a079-088e93bceb26
```

```bash
Generate uuid(s) V4

USAGE:
    blitz generate-uuids [COUNT]

ARGS:
    <COUNT>    Number of uuids V4 to generate [default: 1]
```